### PR TITLE
terraform 0.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ language: python
 branches:
   only:
     - master
+    - tf-0.13
 
 env:
   global:
     # Software versions
-    - TERRAFORM_VERSION=0.12.28
-    - TERRAFORM_PROVIDER_RKE_VERSION=1.0.0
+    - TERRAFORM_VERSION=0.13.0
     - TF_VAR_cluster_name=$(uuidgen -t)
     - TF_VAR_public_net_name="public"
     - TF_VAR_image_name="ubuntu-18.04-docker-x86_64"
@@ -26,10 +26,6 @@ install:
   - sudo unzip /tmp/terraform.zip -d /usr/local/bin
   - sudo chmod +x /usr/local/bin/terraform
   - mkdir -p "$HOME/.terraform.d/plugins/"
-  - travis_retry curl -L
-    "https://github.com/rancher/terraform-provider-rke/releases/download/${TERRAFORM_PROVIDER_RKE_VERSION}/terraform-provider-rke_linux-amd64"
-    -o "$HOME/.terraform.d/plugins/terraform-provider-rke_v1.0.0"
-  - chmod +x "$HOME/.terraform.d/plugins/terraform-provider-rke_v1.0.0"
   - ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa
   - eval "$(ssh-agent -s)"
   - ssh-add

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
 env:
   global:
     # Software versions
-    - TERRAFORM_VERSION=0.13.0
+    - TERRAFORM_VERSION=0.13.1
     - TF_VAR_cluster_name=$(uuidgen -t)
     - TF_VAR_public_net_name="public"
     - TF_VAR_image_name="ubuntu-18.04-docker-x86_64"

--- a/README.md
+++ b/README.md
@@ -9,16 +9,30 @@ Inspired by [Marco Capuccini](https://github.com/mcapuccini/terraform-openstack-
 
 ## Table of contents
 - [Prerequisites](#prerequisites)
+- [Upgrading to Terraform 0.13](#terraform-0.13-upgrade)
 - [Examples](#examples)
 - [Documentation](#documentation)
 
 ## Prerequisites
 
-- [Terraform](https://www.terraform.io/) 0.12+
-- [terraform-provider-rke](https://github.com/rancher/terraform-provider-rke) v1.0.0-beta1+
+- [Terraform](https://www.terraform.io/) 0.13+. For Terraform 0.12.x, use terraform/v0.12 branch.
 - [OpenStack](https://docs.openstack.org/zh_CN/user-guide/common/cli-set-environment-variables-using-openstack-rc.html) environment properly sourced.
 - A Openstack image fullfiling [RKE requirements](https://rancher.com/docs/rke/latest/en/os/).
 - At least one Openstack floating IP.
+
+## Terraform 0.13 upgrade
+
+terraform-openstack-rke >= 0.5 supports Terraform >= 0.13. Some changes in the way Terraform manage providers require manual operations.
+
+```hcl
+terraform 0.13upgrade
+terraform  state replace-provider 'registry.terraform.io/-/rke' 'registry.terraform.io/rancher/rke'
+terraform init
+```
+
+For more informations see [Upgrading to Terraform v0.13](https://www.terraform.io/upgrade-guides/0-13.html)
+
+> :warning: There is some deep changes between 0.4 and 0.5 branches. That will lead to a replacement of the nodes and the rke cluster resources :warning:
 
 ## Examples
 ### Minimal example with master node as egde node and two worker nodes

--- a/USAGE.md
+++ b/USAGE.md
@@ -2,7 +2,7 @@
 
 The following requirements are needed by this module:
 
-- terraform (>=0.12)
+- terraform (>=0.13.1)
 
 - local (>=1.4.0)
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -290,6 +290,30 @@ Default:
 }
 ```
 
+### master\_taints
+
+Description: Master taints
+
+Type: `list(map(string))`
+
+Default: `[]`
+
+### worker\_taints
+
+Description: Worker taints
+
+Type: `list(map(string))`
+
+Default: `[]`
+
+### edge\_taints
+
+Description: Edge taints
+
+Type: `list(map(string))`
+
+Default: `[]`
+
 ### kubernetes\_version
 
 Description: Kubernetes version (RKE)

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ module "secgroup" {
   source       = "./modules/secgroup"
   name_prefix  = "${var.cluster_name}"
   rules        = var.secgroup_rules
-  bastion_host = var.bastion_host != null ? var.bastion_host : module.master.nodes[0].floating_ip
+  bastion_host = var.bastion_host != null ? var.bastion_host : values(module.master.nodes)[0].floating_ip
 }
 
 module "master" {
@@ -86,7 +86,7 @@ module "rke" {
   system_user       = var.system_user
   ssh_key_file      = var.ssh_key_file
   use_ssh_agent     = var.use_ssh_agent
-  bastion_host      = var.bastion_host != null ? var.bastion_host : module.master.nodes[0].floating_ip
+  bastion_host      = var.bastion_host != null ? var.bastion_host : values(module.master.nodes)[0].floating_ip
   wait_for_commands = var.wait_for_commands
   os_auth_url       = var.os_auth_url
   os_password       = var.os_password

--- a/modules/keypair/versions.tf
+++ b/modules/keypair/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    openstack = {
+      source = "terraform-providers/openstack"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/keypair/versions.tf
+++ b/modules/keypair/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "terraform-providers/openstack"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.1"
 }

--- a/modules/network/versions.tf
+++ b/modules/network/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    openstack = {
+      source = "terraform-providers/openstack"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/network/versions.tf
+++ b/modules/network/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "terraform-providers/openstack"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.1"
 }

--- a/modules/node/main.tf
+++ b/modules/node/main.tf
@@ -38,7 +38,6 @@ resource "openstack_compute_floatingip_associate_v2" "associate_floating_ip" {
 data "null_data_source" "nodes" {
   count = var.nodes_count
   inputs = {
-    name        = openstack_compute_instance_v2.instance[count.index].name
     id          = openstack_compute_instance_v2.instance[count.index].id
     internal_ip = openstack_compute_instance_v2.instance[count.index].access_ip_v4
     floating_ip = openstack_networking_floatingip_v2.floating_ip != [] ? openstack_networking_floatingip_v2.floating_ip[count.index].address : ""

--- a/modules/node/output.tf
+++ b/modules/node/output.tf
@@ -3,5 +3,5 @@ output "associate_floating_ip" {
 }
 
 output "nodes" {
-  value = data.null_data_source.nodes[*].outputs
+  value = zipmap(openstack_compute_instance_v2.instance[*].name, data.null_data_source.nodes[*].outputs)
 }

--- a/modules/node/versions.tf
+++ b/modules/node/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    null = {
+      source = "hashicorp/null"
+    }
+    openstack = {
+      source = "terraform-providers/openstack"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/node/versions.tf
+++ b/modules/node/versions.tf
@@ -7,5 +7,5 @@ terraform {
       source = "terraform-providers/openstack"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.1"
 }

--- a/modules/rke/main.tf
+++ b/modules/rke/main.tf
@@ -1,10 +1,13 @@
 resource "null_resource" "wait_for_master_ssh" {
-  count = length(var.master_nodes)
+  for_each = var.master_nodes
+#  for_each = {
+#    for node in var.master_nodes: node.name => node
+#  }
   triggers = {
-    node_instance_id = var.master_nodes[count.index].id
+    node_instance_id = each.value.id
   }
   connection {
-    host        = var.master_nodes[count.index].floating_ip
+    host        = each.value.floating_ip
     user        = var.system_user
     private_key = var.use_ssh_agent ? null : file(var.ssh_key_file)
     agent       = var.use_ssh_agent
@@ -15,12 +18,12 @@ resource "null_resource" "wait_for_master_ssh" {
 }
 
 resource "null_resource" "wait_for_edge_ssh" {
-  count = length(var.edge_nodes)
+  for_each = var.edge_nodes
   triggers = {
-    node_instance_id = var.edge_nodes[count.index].id
+    node_instance_id = each.value.id
   }
   connection {
-    host        = var.edge_nodes[count.index].floating_ip
+    host        = each.value.floating_ip
     user        = var.system_user
     private_key = var.use_ssh_agent ? null : file(var.ssh_key_file)
     agent       = var.use_ssh_agent
@@ -31,13 +34,13 @@ resource "null_resource" "wait_for_edge_ssh" {
 }
 
 resource "null_resource" "wait_for_worker_ssh" {
-  count = length(var.worker_nodes)
+  for_each = var.worker_nodes
   triggers = {
-    node_instance_id = var.worker_nodes[count.index].id
+    node_instance_id = each.value.id
   }
   connection {
     bastion_host = var.bastion_host
-    host         = var.worker_nodes[count.index].internal_ip
+    host         = each.value.internal_ip
     user         = var.system_user
     private_key  = var.use_ssh_agent ? null : file(var.ssh_key_file)
     agent        = var.use_ssh_agent
@@ -61,7 +64,7 @@ resource "rke_cluster" "cluster" {
     content {
       address           = nodes.value.floating_ip != "" ? nodes.value.floating_ip : nodes.value.internal_ip
       internal_address  = nodes.value.internal_ip
-      hostname_override = nodes.value.name
+      hostname_override = nodes.key
       user              = var.system_user
       role              = ["controlplane", "etcd"]
       labels            = var.master_labels
@@ -81,7 +84,7 @@ resource "rke_cluster" "cluster" {
     content {
       address           = nodes.value.floating_ip != "" ? nodes.value.floating_ip : nodes.value.internal_ip
       internal_address  = nodes.value.internal_ip
-      hostname_override = nodes.value.name
+      hostname_override = nodes.key
       user              = var.system_user
       role              = ["worker"]
       labels            = var.edge_labels
@@ -101,7 +104,7 @@ resource "rke_cluster" "cluster" {
     content {
       address           = nodes.value.floating_ip != "" ? nodes.value.floating_ip : nodes.value.internal_ip
       internal_address  = nodes.value.internal_ip
-      hostname_override = nodes.value.name
+      hostname_override = nodes.key
       user              = var.system_user
       role              = ["worker"]
       labels            = var.worker_labels

--- a/modules/rke/versions.tf
+++ b/modules/rke/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    local = {
+      source = "hashicorp/local"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+    openstack = {
+      source = "terraform-providers/openstack"
+    }
+    rke = {
+      source  = "rancher/rke"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/rke/versions.tf
+++ b/modules/rke/versions.tf
@@ -13,5 +13,5 @@ terraform {
       source  = "rancher/rke"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.1"
 }

--- a/modules/secgroup/main.tf
+++ b/modules/secgroup/main.tf
@@ -18,12 +18,15 @@ resource "openstack_networking_secgroup_rule_v2" "tunnel_rule" {
 }
 
 resource "openstack_networking_secgroup_rule_v2" "rules" {
-  count             = length(var.rules)
+  for_each          = {
+    for rule in var.rules :
+    format("%s-%s-%s", rule["source"], rule["protocol"], rule["port"]) => rule
+  }
   direction         = "ingress"
   ethertype         = "IPv4"
-  protocol          = var.rules[count.index].protocol
-  port_range_min    = var.rules[count.index].port
-  port_range_max    = var.rules[count.index].port
-  remote_ip_prefix  = var.rules[count.index].source
+  protocol          = each.value.protocol
+  port_range_min    = each.value.port
+  port_range_max    = each.value.port
+  remote_ip_prefix  = each.value.source
   security_group_id = openstack_networking_secgroup_v2.secgroup.id
 }

--- a/modules/secgroup/output.tf
+++ b/modules/secgroup/output.tf
@@ -3,5 +3,5 @@ output "secgroup_name" {
 }
 
 output "secgroup_rules" {
-  value = concat([openstack_networking_secgroup_rule_v2.default_rule, openstack_networking_secgroup_rule_v2.tunnel_rule], openstack_networking_secgroup_rule_v2.rules)
+  value = concat([openstack_networking_secgroup_rule_v2.default_rule, openstack_networking_secgroup_rule_v2.tunnel_rule], values(openstack_networking_secgroup_rule_v2.rules))
 }

--- a/modules/secgroup/versions.tf
+++ b/modules/secgroup/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    openstack = {
+      source = "terraform-providers/openstack"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/secgroup/versions.tf
+++ b/modules/secgroup/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "terraform-providers/openstack"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.1"
 }

--- a/requirements.tf
+++ b/requirements.tf
@@ -1,9 +1,0 @@
-terraform {
-  required_version = ">=0.12"
-  required_providers {
-    local     = ">=1.4.0"
-    null      = ">=2.1.2"
-    openstack = ">=1.24.0"
-    rke       = ">=1.0.0"
-  }
-}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">=0.12"
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = ">=1.4.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">=2.1.2"
+    }
+    openstack = {
+      source  = "terraform-providers/openstack"
+      version = ">=1.24.0"
+    }
+    rke = {
+      source  = "rancher/rke"
+      version = ">=1.0.0"
+    }
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.12"
+  required_version = ">=0.13.1"
   required_providers {
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
This PR ensures terraform 0.13 compatibility.
It uses `for_each` instead where makes sense.