### PR TITLE
Add ability to deploy node instances with attached boot volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ You can set [affinity policy](https://www.terraform.io/docs/providers/openstack/
 You can use `wait_for_commands` to specify a list of commands to be run before invoking RKE. It can be useful when installing Docker at provision time (note that cooking your image embedding Docker with [Packer](https://packer.io) is a better practice though) :
 `wait_for_commands = ["while docker info ; [ $? -ne 0 ]; do echo wait for docker; sleep 30 ; done"]`
 
+#### Boot from volume
+
+Some providers require to boot the instances from an attached boot volume instead of the nova ephemeral volume.
+To enable this feature, provide the variables to the config file:
+
+```hcl
+boot_from_volume = true
+boot_volume_size = 20
+```
+
 ### Kubernetes version
 
 You can specify kubernetes version with `kubernetes_version` variables. Refer to RKE supported version.

--- a/USAGE.md
+++ b/USAGE.md
@@ -209,6 +209,22 @@ Type: `string`
 
 Default: `null`
 
+### boot\_from\_volume
+
+Description: Boot the node instances from an attached volume
+
+Type: `bool`
+
+Default: `false`
+
+### boot\_volume\_size
+
+Description: The size of the boot volume in GB
+
+Type: `number`
+
+Default: `20`
+
 ### system\_user
 
 Description: Default OS image user

--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,8 @@ module "master" {
   config_drive       = var.nodes_config_drive
   floating_ip_pool   = var.public_net_name
   user_data          = var.user_data_file != null ? file(var.user_data_file) : null
+  boot_from_volume   = var.boot_from_volume
+  boot_volume_size   = var.boot_volume_size
 }
 
 module "edge" {
@@ -55,6 +57,8 @@ module "edge" {
   config_drive       = var.nodes_config_drive
   floating_ip_pool   = var.public_net_name
   user_data          = var.user_data_file != null ? file(var.user_data_file) : null
+  boot_from_volume   = var.boot_from_volume
+  boot_volume_size   = var.boot_volume_size
 }
 
 module "worker" {
@@ -71,6 +75,8 @@ module "worker" {
   config_drive     = var.nodes_config_drive
   floating_ip_pool = var.public_net_name
   user_data        = var.user_data_file != null ? file(var.user_data_file) : null
+  boot_from_volume   = var.boot_from_volume
+  boot_volume_size   = var.boot_volume_size
 }
 
 module "rke" {

--- a/modules/node/variables.tf
+++ b/modules/node/variables.tf
@@ -52,3 +52,11 @@ variable "floating_ip_pool" {
 variable "user_data" {
   type = string
 }
+
+variable "boot_from_volume" {
+  type    = bool
+}
+
+variable "boot_volume_size" {
+  type    = number
+}

--- a/variables.tf
+++ b/variables.tf
@@ -135,6 +135,18 @@ variable "user_data_file" {
   description = "User data file to provide when launching the instance"
 }
 
+variable "boot_from_volume" {
+  type        = bool
+  default     = false
+  description = "Boot nodes from volume"
+}
+
+variable "boot_volume_size" {
+  type        = number
+  default     = 20
+  description = "The size of the boot volume"
+}
+
 #################
 # RKE variables #
 #################


### PR DESCRIPTION
This PR adds the ability to deploy node instances with attached boot volumes as required by some providers.