### PR TITLE
Expose `nodes_subnet`

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -23,3 +23,8 @@ output "rke_cluster" {
   description = "RKE cluster spec"
   sensitive   = "true"
 }
+
+output "nodes_subnet" {
+  value       = module.network.nodes_subnet
+  description = "The nodes subnet"
+}


### PR DESCRIPTION
This PR exposes the `nodes_subnet` resource to be consumed in calling manifests.